### PR TITLE
fix: replace swww with awww

### DIFF
--- a/install-scripts/01-hypr-pkgs.sh
+++ b/install-scripts/01-hypr-pkgs.sh
@@ -18,83 +18,83 @@ Extra=(
 )
 
 hypr_package=(
-  #aylurs-gtk-shell
-  bc
-  cliphist
-  curl
-  grim
-  gvfs
-  gvfs-mtp
-  hyprpolkitagent
-  hyprsunset
-  imagemagick
-  inxi
-  jq
-  kitty
-  kvantum
-  kvantum-qt5
-  libspng
-  nano
-  network-manager-applet
-  pamixer
-  pavucontrol
-  libpulse
-  playerctl
-  python-requests
-  python-pyquery
-  qt5ct
-  qt5-declarative
-  qt5-quickcontrols2
-  qt6ct
-  qt6-declarative
-  qt6-svg
-  rofi
-  slurp
-  swappy
-  swaync
-  swww
-  unzip # needed later
-  uwsm  # In case someone selects USWM login
-  wallust
-  waybar
-  wget
-  wl-clipboard
-  wlogout
-  xfce-polkit
-  xdg-user-dirs
-  xdg-utils
-  yad
+        #aylurs-gtk-shell
+        bc
+        cliphist
+        curl
+        grim
+        gvfs
+        gvfs-mtp
+        hyprpolkitagent
+        hyprsunset
+        imagemagick
+        inxi
+        jq
+        kitty
+        kvantum
+        kvantum-qt5
+        libspng
+        nano
+        network-manager-applet
+        pamixer
+        pavucontrol
+        libpulse
+        playerctl
+        python-requests
+        python-pyquery
+        qt5ct
+        qt5-declarative
+        qt5-quickcontrols2
+        qt6ct
+        qt6-declarative
+        qt6-svg
+        rofi
+        slurp
+        swappy
+        swaync
+        awww
+        unzip # needed later
+        uwsm  # In case someone selects USWM login
+        wallust
+        waybar
+        wget
+        wl-clipboard
+        wlogout
+        xfce-polkit
+        xdg-user-dirs
+        xdg-utils
+        yad
 )
 
 # the following packages can be deleted. however, dotfiles may not work properly
 hypr_package_2=(
-  brightnessctl
-  btop
-  cava
-  loupe
-  fastfetch
-  gnome-system-monitor
-  mousepad
-  mpv
-  mpv-mpris
-  nvtop
-  nwg-look
-  nwg-displays
-  pacman-contrib
-  qalculate-gtk
-  yt-dlp
+        brightnessctl
+        btop
+        cava
+        loupe
+        fastfetch
+        gnome-system-monitor
+        mousepad
+        mpv
+        mpv-mpris
+        nvtop
+        nwg-look
+        nwg-displays
+        pacman-contrib
+        qalculate-gtk
+        yt-dlp
 )
 
 # List of packages to uninstall as it conflicts some packages
 uninstall=(
-  aylurs-gtk-shell
-  dunst
-  cachyos-hyprland-settings
-  mako
-  rofi
-  wallust-git
-  rofi-lbonn-wayland
-  rofi-lbonn-wayland-git
+        aylurs-gtk-shell
+        dunst
+        cachyos-hyprland-settings
+        mako
+        rofi
+        wallust-git
+        rofi-lbonn-wayland
+        rofi-lbonn-wayland-git
 )
 
 ## WARNING: DO NOT EDIT BEYOND THIS LINE IF YOU DON'T KNOW WHAT YOU ARE DOING! ##
@@ -103,14 +103,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Change the working directory to the parent directory of the script
 PARENT_DIR="$SCRIPT_DIR/.."
 cd "$PARENT_DIR" || {
-  echo "${ERROR} Failed to change directory to $PARENT_DIR"
-  exit 1
+        echo "${ERROR} Failed to change directory to $PARENT_DIR"
+        exit 1
 }
 
 # Source the global functions script
 if ! source "$(dirname "$(readlink -f "$0")")/Global_functions.sh"; then
-  echo "Failed to source Global_functions.sh"
-  exit 1
+        echo "Failed to source Global_functions.sh"
+        exit 1
 fi
 
 # Set the name of the log file to include the current date and time
@@ -118,28 +118,28 @@ LOG="Install-Logs/install-$(date +%d-%H%M%S)_hypr-pkgs.log"
 # rofi v2.x presence check (do not remove if already on v2.x)
 skip_rofi_uninstall=false
 if pacman -Qi rofi &>/dev/null; then
-  rofi_version="$(pacman -Qi rofi | awk -F': ' '/Version/{print $2}' | cut -d- -f1)"
-  if [[ "${rofi_version%%.*}" == "2" ]]; then
-    skip_rofi_uninstall=true
-    echo -e "${INFO} rofi ${rofi_version} detected. Skipping uninstall of rofi."
-  fi
+        rofi_version="$(pacman -Qi rofi | awk -F': ' '/Version/{print $2}' | cut -d- -f1)"
+        if [[ "${rofi_version%%.*}" == "2" ]]; then
+                skip_rofi_uninstall=true
+                echo -e "${INFO} rofi ${rofi_version} detected. Skipping uninstall of rofi."
+        fi
 fi
 
 # conflicting packages removal
 overall_failed=0
 printf "\n%s - ${SKY_BLUE}Removing some packages${RESET} as it conflicts with KooL's Hyprland Dots \n" "${NOTE}"
 for PKG in "${uninstall[@]}"; do
-  if [[ "$PKG" == "rofi" && "$skip_rofi_uninstall" == "true" ]]; then
-    continue
-  fi
-  uninstall_package "$PKG" 2>&1 | tee -a "$LOG"
-  if [ $? -ne 0 ]; then
-    overall_failed=1
-  fi
+        if [[ "$PKG" == "rofi" && "$skip_rofi_uninstall" == "true" ]]; then
+                continue
+        fi
+        uninstall_package "$PKG" 2>&1 | tee -a "$LOG"
+        if [ $? -ne 0 ]; then
+                overall_failed=1
+        fi
 done
 
 if [ $overall_failed -ne 0 ]; then
-  echo -e "${ERROR} Some packages failed to uninstall. Please check the log."
+        echo -e "${ERROR} Some packages failed to uninstall. Please check the log."
 fi
 
 printf "\n%.0s" {1..1}
@@ -148,17 +148,17 @@ printf "\n%.0s" {1..1}
 printf "\n%s - Installing ${SKY_BLUE}KooL's Hyprland necessary packages${RESET} .... \n" "${NOTE}"
 
 for PKG1 in "${hypr_package[@]}" "${hypr_package_2[@]}" "${Extra[@]}"; do
-  install_package "$PKG1" "$LOG"
+        install_package "$PKG1" "$LOG"
 done
 
 printf "\n%.0s" {1..2}
 
 # Ensure hyprpolkitagent user service is enabled and running
 if systemctl --user list-unit-files 2>/dev/null | grep -q '^hyprpolkitagent\.service'; then
-  if ! systemctl --user is-enabled --quiet hyprpolkitagent 2>/dev/null; then
-    systemctl --user enable hyprpolkitagent 2>&1 | tee -a "$LOG" || true
-  fi
-  if ! systemctl --user is-active --quiet hyprpolkitagent 2>/dev/null; then
-    systemctl --user start hyprpolkitagent 2>&1 | tee -a "$LOG" || true
-  fi
+        if ! systemctl --user is-enabled --quiet hyprpolkitagent 2>/dev/null; then
+                systemctl --user enable hyprpolkitagent 2>&1 | tee -a "$LOG" || true
+        fi
+        if ! systemctl --user is-active --quiet hyprpolkitagent 2>/dev/null; then
+                systemctl --user start hyprpolkitagent 2>&1 | tee -a "$LOG" || true
+        fi
 fi

--- a/install-scripts/02-Final-Check.sh
+++ b/install-scripts/02-Final-Check.sh
@@ -10,24 +10,24 @@
 # NOTE: These package check are only the essentials
 
 packages=(
-  cliphist
-  kvantum
-  kvantum-qt5
-  qt5-declarative
-  qt5-quickcontrols2
-  qt6-declarative
-  rofi-wayland
-  imagemagick
-  swaync
-  swww
-  wallust
-  waybar
-  wl-clipboard
-  wlogout
-  kitty
-  hypridle
-  hyprlock
-  hyprland
+        cliphist
+        kvantum
+        kvantum-qt5
+        qt5-declarative
+        qt5-quickcontrols2
+        qt6-declarative
+        rofi-wayland
+        imagemagick
+        swaync
+        awww
+        wallust
+        waybar
+        wl-clipboard
+        wlogout
+        kitty
+        hypridle
+        hyprlock
+        hyprland
 )
 
 # Local packages that should be in /usr/local/bin/
@@ -37,11 +37,14 @@ local_pkgs_installed=(
 
 ## WARNING: DO NOT EDIT BEYOND THIS LINE IF YOU DON'T KNOW WHAT YOU ARE DOING! ##
 # Determine the directory where the script is located
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Change the working directory to the parent directory of the script
 PARENT_DIR="$SCRIPT_DIR/.."
-cd "$PARENT_DIR" || { echo "${ERROR} Failed to change directory to $PARENT_DIR"; exit 1; }
+cd "$PARENT_DIR" || {
+        echo "${ERROR} Failed to change directory to $PARENT_DIR"
+        exit 1
+}
 
 # Source the global functions script
 source "$(dirname "$(readlink -f "$0")")/Global_functions.sh"
@@ -56,53 +59,52 @@ local_missing=()
 
 # Function to check if a packages are installed using pacman
 is_installed_pacman() {
-    pacman -Qi "$1" &>/dev/null
+        pacman -Qi "$1" &>/dev/null
 }
 
 # Loop through each package
 for pkg in "${packages[@]}"; do
-    # Check if the packages are installed
-    if ! is_installed_pacman "$pkg"; then
-        missing+=("$pkg")
-    fi
+        # Check if the packages are installed
+        if ! is_installed_pacman "$pkg"; then
+                missing+=("$pkg")
+        fi
 done
 
 # Check for local packages
 for pkg1 in "${local_pkgs_installed[@]}"; do
-    if ! [ -f "/usr/local/bin/$pkg1" ]; then
-        local_missing+=("$pkg1")
-    fi
+        if ! [ -f "/usr/local/bin/$pkg1" ]; then
+                local_missing+=("$pkg1")
+        fi
 done
 
 # Log missing packages
 if [ ${#missing[@]} -eq 0 ] && [ ${#local_missing[@]} -eq 0 ]; then
-    echo "${OK} GREAT! All ${YELLOW}essential packages${RESET} have been successfully installed." | tee -a "$LOG"
+        echo "${OK} GREAT! All ${YELLOW}essential packages${RESET} have been successfully installed." | tee -a "$LOG"
 else
-    if [ ${#missing[@]} -ne 0 ]; then
-        echo "${WARN} The following packages are not installed and will be logged:"
-        for pkg in "${missing[@]}"; do
-            echo "${WARNING}$pkg${RESET}"
-            echo "$pkg" >> "$LOG" 
-        done
-    fi
+        if [ ${#missing[@]} -ne 0 ]; then
+                echo "${WARN} The following packages are not installed and will be logged:"
+                for pkg in "${missing[@]}"; do
+                        echo "${WARNING}$pkg${RESET}"
+                        echo "$pkg" >>"$LOG"
+                done
+        fi
 
-    if [ ${#local_missing[@]} -ne 0 ]; then
-        echo "${WARN} The following local packages are missing from /usr/local/bin/ and will be logged:"
-        for pkg1 in "${local_missing[@]}"; do
-            echo "${WARNING}$pkg1${REST} is not installed. Can't find it in /usr/local/bin/"
-            echo "$pkg1" >> "$LOG" 
-        done
-    fi
+        if [ ${#local_missing[@]} -ne 0 ]; then
+                echo "${WARN} The following local packages are missing from /usr/local/bin/ and will be logged:"
+                for pkg1 in "${local_missing[@]}"; do
+                        echo "${WARNING}$pkg1${REST} is not installed. Can't find it in /usr/local/bin/"
+                        echo "$pkg1" >>"$LOG"
+                done
+        fi
 
-    echo "${NOTE} Missing packages logged at $(date)" >> "$LOG"
+        echo "${NOTE} Missing packages logged at $(date)" >>"$LOG"
 fi
 
 # Check hyprpolkitagent user service status
 if systemctl --user list-unit-files 2>/dev/null | grep -q '^hyprpolkitagent\.service'; then
-    if systemctl --user is-active --quiet hyprpolkitagent 2>/dev/null; then
-        echo "${OK} hyprpolkitagent user service is running." | tee -a "$LOG"
-    else
-        echo "${WARN} hyprpolkitagent user service is not running." | tee -a "$LOG"
-    fi
+        if systemctl --user is-active --quiet hyprpolkitagent 2>/dev/null; then
+                echo "${OK} hyprpolkitagent user service is running." | tee -a "$LOG"
+        else
+                echo "${WARN} hyprpolkitagent user service is not running." | tee -a "$LOG"
+        fi
 fi
-

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -36,7 +36,7 @@ printf "\n%.0s" {1..1}
 
 # Show welcome message using whiptail with Yes/No options
 whiptail --title "Arch-Hyprland KooL Dots Uninstall Script" --yesno \
-"Hello! This script will uninstall KooL Hyprland packages and configs.
+        "Hello! This script will uninstall KooL Hyprland packages and configs.
 
 You can choose packages and directories you want to remove.
 NOTE: This will remove configs from ~/.config
@@ -46,183 +46,183 @@ WARNING: After uninstallation, your system may become unstable.
 Shall we Proceed?" 20 80
 
 if [ $? -eq 1 ]; then
-    echo "$INFO uninstall process canceled."
-    exit 0
+        echo "$INFO uninstall process canceled."
+        exit 0
 fi
 
 # Function to remove selected packages
 remove_packages() {
-    local selected_packages_file=$1
-    while read -r package; do
-        if pacman -Qi "$package" &> /dev/null; then
-            echo "Removing package: $package"
-            if ! sudo pacman -Rs --noconfirm "$package"; then
-                echo "$ERROR Failed to remove package: $package"
-            else
-                echo "$OK Successfully removed package: $package"
-            fi
-        else
-            echo "$INFO Package ${YELLOW}$package${RESET} not found. Skipping."
-        fi
-    done < "$selected_packages_file"
+        local selected_packages_file=$1
+        while read -r package; do
+                if pacman -Qi "$package" &>/dev/null; then
+                        echo "Removing package: $package"
+                        if ! sudo pacman -Rs --noconfirm "$package"; then
+                                echo "$ERROR Failed to remove package: $package"
+                        else
+                                echo "$OK Successfully removed package: $package"
+                        fi
+                else
+                        echo "$INFO Package ${YELLOW}$package${RESET} not found. Skipping."
+                fi
+        done <"$selected_packages_file"
 }
 
 # Function to remove selected directories
 remove_directories() {
-    local selected_dirs_file=$1
-    while read -r dir; do
-        pattern="$HOME/.config/$dir*"        
-        # Loop through directories matching the pattern
-        for dir_to_remove in $pattern; do
-            if [ -d "$dir_to_remove" ]; then
-                echo "Removing directory: $dir_to_remove"
-                if ! rm -rf "$dir_to_remove"; then
-                    echo "$ERROR Failed to remove directory: $dir_to_remove"
-                else
-                    echo "$OK Successfully removed directory: $dir_to_remove"
-                fi
-            else
-                echo "$INFO Directory ${YELLOW}$dir_to_remove${RESET} not found. Skipping."
-            fi
-        done
-    done < "$selected_dirs_file"
+        local selected_dirs_file=$1
+        while read -r dir; do
+                pattern="$HOME/.config/$dir*"
+                # Loop through directories matching the pattern
+                for dir_to_remove in $pattern; do
+                        if [ -d "$dir_to_remove" ]; then
+                                echo "Removing directory: $dir_to_remove"
+                                if ! rm -rf "$dir_to_remove"; then
+                                        echo "$ERROR Failed to remove directory: $dir_to_remove"
+                                else
+                                        echo "$OK Successfully removed directory: $dir_to_remove"
+                                fi
+                        else
+                                echo "$INFO Directory ${YELLOW}$dir_to_remove${RESET} not found. Skipping."
+                        fi
+                done
+        done <"$selected_dirs_file"
 }
 
 # Define the list of packages to choose from (with options_command tags)
 packages=(
-    "btop" "resource monitor" "off"
-    "brightnessctl" "brightnessctl" "off"
-    "cava" "Cross-platform Audio Visualizer" "off"
-    "cliphist" "clipboard manager" "off"
-    "fastfetch" "fastfetch" "off"
-    "ffmpegthumbnailer" "FFmpeg Thumbnailer" "off"
-    "grim" "screenshot tool" "off"
-    "imagemagick" "Image manipulation tool" "off"
-    "kitty" "kitty-terminal" "off"
-    "kvantum" "QT apps theming" "off"
-    "kvantum-qt5" "QT apps theming" "off"
-    "qt5-declarative" "QT apps theming" "off"
-    "qt5-quickcontrols2" "QT apps theming" "off"
-    "mousepad" "simple text editor" "off"
-    "mpv" "multi-media player" "off"
-    "mpv-mpris" "mpv-plugin" "off"
-    "network-manager-applet" "network-manager-applet" "off"
-    "nvtop" "gpu resource monitor" "off"
-    "nwg-displays" "display monitor configuration app" "off"
-    "nwg-look" "gtk settings app" "off"
-    "pamixer" "pamixer" "off"
-    "pokemon-colorscripts-git" "terminal colorscripts" "off"
-    "pavucontrol" "pavucontrol" "off"
-    "playerctl" "playerctl" "off"
-    "pyprland" "pyprland" "off"
-    "qalculate-gtk" "calculator - QT" "off"
-    "qt5ct" "qt5ct" "off"
-    "qt6ct" "qt6ct" "off"
-    "qt6-declarative" "QT apps theming" "off"
-    "quickshell" "quickshell" "off"
-    "rofi-wayland" "rofi-wayland" "off"
-    "slurp" "screenshot tool" "off"
-    "swappy" "screenshot tool" "off"
-    "swaync" "notification agent" "off"
-    "swww" "wallpaper engine" "off"
-    "thunar" "File Manager" "off"
-    "thunar-archive-plugin" "Archive Plugin" "off"
-    "thunar-volman" "Volume Management" "off"
-    "tumbler" "Thumbnail Service" "off"
-    "wallust" "color pallete generator" "off"
-    "waybar" "wayland bar" "off"
-    "wl-clipboard" "clipboard manager" "off"
-    "wlogout" "logout menu" "off"
-    "xdg-desktop-portal-hyprland" "hyprland file picker" "off"
-    "yad" "dialog box" "off"
-    "yt-dlp" "video downloader" "off"
-    "xarchiver" "Archive Manager" "off"
-    "hypridle" "hyprland idling agent" "off"
-    "hyprlock" "lockscreen" "off"
-    "hyprpolkitagent" "hyprland polkit agent" "off"
-    "xfce-polkit" "polkit agent" "off"
-    "hyprland" "hyprland main package" "off"
+        "btop" "resource monitor" "off"
+        "brightnessctl" "brightnessctl" "off"
+        "cava" "Cross-platform Audio Visualizer" "off"
+        "cliphist" "clipboard manager" "off"
+        "fastfetch" "fastfetch" "off"
+        "ffmpegthumbnailer" "FFmpeg Thumbnailer" "off"
+        "grim" "screenshot tool" "off"
+        "imagemagick" "Image manipulation tool" "off"
+        "kitty" "kitty-terminal" "off"
+        "kvantum" "QT apps theming" "off"
+        "kvantum-qt5" "QT apps theming" "off"
+        "qt5-declarative" "QT apps theming" "off"
+        "qt5-quickcontrols2" "QT apps theming" "off"
+        "mousepad" "simple text editor" "off"
+        "mpv" "multi-media player" "off"
+        "mpv-mpris" "mpv-plugin" "off"
+        "network-manager-applet" "network-manager-applet" "off"
+        "nvtop" "gpu resource monitor" "off"
+        "nwg-displays" "display monitor configuration app" "off"
+        "nwg-look" "gtk settings app" "off"
+        "pamixer" "pamixer" "off"
+        "pokemon-colorscripts-git" "terminal colorscripts" "off"
+        "pavucontrol" "pavucontrol" "off"
+        "playerctl" "playerctl" "off"
+        "pyprland" "pyprland" "off"
+        "qalculate-gtk" "calculator - QT" "off"
+        "qt5ct" "qt5ct" "off"
+        "qt6ct" "qt6ct" "off"
+        "qt6-declarative" "QT apps theming" "off"
+        "quickshell" "quickshell" "off"
+        "rofi-wayland" "rofi-wayland" "off"
+        "slurp" "screenshot tool" "off"
+        "swappy" "screenshot tool" "off"
+        "swaync" "notification agent" "off"
+        "awww" "wallpaper engine" "off"
+        "thunar" "File Manager" "off"
+        "thunar-archive-plugin" "Archive Plugin" "off"
+        "thunar-volman" "Volume Management" "off"
+        "tumbler" "Thumbnail Service" "off"
+        "wallust" "color pallete generator" "off"
+        "waybar" "wayland bar" "off"
+        "wl-clipboard" "clipboard manager" "off"
+        "wlogout" "logout menu" "off"
+        "xdg-desktop-portal-hyprland" "hyprland file picker" "off"
+        "yad" "dialog box" "off"
+        "yt-dlp" "video downloader" "off"
+        "xarchiver" "Archive Manager" "off"
+        "hypridle" "hyprland idling agent" "off"
+        "hyprlock" "lockscreen" "off"
+        "hyprpolkitagent" "hyprland polkit agent" "off"
+        "xfce-polkit" "polkit agent" "off"
+        "hyprland" "hyprland main package" "off"
 )
 
 # Define the list of directories to choose from (with options_command tags)
 directories=(
-    "btop" "btop configuration" "off"
-    "cava" "cava configuration" "off"
-    "fastfetch" "fastfetch configuration" "off"
-    "hypr" "main hyprland configuration" "off"
-    "kitty" "kitty terminal configuration" "off"
-    "Kvantum" "Kvantum-manager configuration" "off"
-    "quickshell" "quickshell desktop overview configuration" "off"
-    "qt5ct" "qt5ct configuration" "off"
-    "qt6ct" "qt6ct configuration" "off"
-    "rofi" "rofi configuration" "off"
-    "swappy" "swappy (screenshot tool) configuration" "off"
-    "swaync" "swaync (notification agent) configuration" "off"
-    "Thunar" "Thunar file manager configuration" "off"
-    "wallust" "wallust (color pallete) configuration" "off"
-    "waybar" "waybar configuration" "off"
-    "wlogout" "wlogout (logout menu) configuration" "off"    
+        "btop" "btop configuration" "off"
+        "cava" "cava configuration" "off"
+        "fastfetch" "fastfetch configuration" "off"
+        "hypr" "main hyprland configuration" "off"
+        "kitty" "kitty terminal configuration" "off"
+        "Kvantum" "Kvantum-manager configuration" "off"
+        "quickshell" "quickshell desktop overview configuration" "off"
+        "qt5ct" "qt5ct configuration" "off"
+        "qt6ct" "qt6ct configuration" "off"
+        "rofi" "rofi configuration" "off"
+        "swappy" "swappy (screenshot tool) configuration" "off"
+        "swaync" "swaync (notification agent) configuration" "off"
+        "Thunar" "Thunar file manager configuration" "off"
+        "wallust" "wallust (color pallete) configuration" "off"
+        "waybar" "waybar configuration" "off"
+        "wlogout" "wlogout (logout menu) configuration" "off"
 )
 
 # Loop for package selection until user selects something or cancels
 while true; do
-    package_choices=$(whiptail --title "Select Packages to Uninstall" --checklist \
-    "Select the packages you want to remove\nNOTE: 'SPACEBAR' to select & 'TAB' key to change selection" 35 90 25 \
-    "${packages[@]}" 3>&1 1>&2 2>&3)
+        package_choices=$(whiptail --title "Select Packages to Uninstall" --checklist \
+                "Select the packages you want to remove\nNOTE: 'SPACEBAR' to select & 'TAB' key to change selection" 35 90 25 \
+                "${packages[@]}" 3>&1 1>&2 2>&3)
 
-    # Check if the user canceled the operation
-    if [ $? -eq 1 ]; then
-        echo "$INFO uninstall process canceled."
-        exit 0
-    fi
+        # Check if the user canceled the operation
+        if [ $? -eq 1 ]; then
+                echo "$INFO uninstall process canceled."
+                exit 0
+        fi
 
-    # If no packages are selected, ask again
-    if [[ -z "$package_choices" ]]; then
-        echo "$NOTE No packages selected. Please select at least one package."
-    else
-        echo "$package_choices" | tr -d '"' | tr ' ' '\n' > /tmp/selected_packages.txt
-        echo "Packages to remove: $package_choices"
-        break
-    fi
+        # If no packages are selected, ask again
+        if [[ -z "$package_choices" ]]; then
+                echo "$NOTE No packages selected. Please select at least one package."
+        else
+                echo "$package_choices" | tr -d '"' | tr ' ' '\n' >/tmp/selected_packages.txt
+                echo "Packages to remove: $package_choices"
+                break
+        fi
 done
 
 # Loop for directory selection until user selects something or cancels
 while true; do
-    dir_choices=$(whiptail --title "Select Directories to Remove" --checklist \
-    "Select the directories you want to remove\nNOTE: This will remove configs from ~/.config\n\nNOTE: 'SPACEBAR' to select & 'TAB' key to change selection" 28 90 18 \
-    "${directories[@]}" 3>&1 1>&2 2>&3)
+        dir_choices=$(whiptail --title "Select Directories to Remove" --checklist \
+                "Select the directories you want to remove\nNOTE: This will remove configs from ~/.config\n\nNOTE: 'SPACEBAR' to select & 'TAB' key to change selection" 28 90 18 \
+                "${directories[@]}" 3>&1 1>&2 2>&3)
 
-    # Check if the user canceled the operation
-    if [ $? -eq 1 ]; then
-        echo "$INFO uninstall process canceled."
-        exit 0
-    fi
+        # Check if the user canceled the operation
+        if [ $? -eq 1 ]; then
+                echo "$INFO uninstall process canceled."
+                exit 0
+        fi
 
-    # If no directories are selected, ask again
-    if [[ -z "$dir_choices" ]]; then
-        echo "$NOTE No directories selected. Please select at least one directory."
-    else
-        # Save each selected directory to a new line in the temporary file
-        echo "$dir_choices" | tr -d '"' | tr ' ' '\n' > /tmp/selected_directories.txt
-        echo "Directories to remove: $dir_choices"
-        break
-    fi
+        # If no directories are selected, ask again
+        if [[ -z "$dir_choices" ]]; then
+                echo "$NOTE No directories selected. Please select at least one directory."
+        else
+                # Save each selected directory to a new line in the temporary file
+                echo "$dir_choices" | tr -d '"' | tr ' ' '\n' >/tmp/selected_directories.txt
+                echo "Directories to remove: $dir_choices"
+                break
+        fi
 done
 
 # First confirmation - Warning about potential instability
 if ! whiptail --title "Warning" --yesno \
-"Warning: Removing these packages and directories may cause your system to become unstable and you may not be able to recover it.\n\nAre you sure you want to proceed?" \
-10 80; then
-    echo "$INFO uninstall process canceled."
-    exit 0
+        "Warning: Removing these packages and directories may cause your system to become unstable and you may not be able to recover it.\n\nAre you sure you want to proceed?" \
+        10 80; then
+        echo "$INFO uninstall process canceled."
+        exit 0
 fi
 
 # Second confirmation - Final confirmation to proceed
 if ! whiptail --title "Final Confirmation" --yesno \
-"Are you absolutely sure you want to remove the selected packages and directories?\n\nWARNING! This action is irreversible." \
-10 80; then
-    echo "$INFO uninstall process canceled."
-    exit 0
+        "Are you absolutely sure you want to remove the selected packages and directories?\n\nWARNING! This action is irreversible." \
+        10 80; then
+        echo "$INFO uninstall process canceled."
+        exit 0
 fi
 
 printf "\n%.0s" {1..1}
@@ -230,32 +230,32 @@ printf "\n%s${SKY_BLUE}Attempting to remove selected packages${RESET}\n" "${NOTE
 MAX_ATTEMPTS=2
 ATTEMPT=0
 while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
-    # Remove packages
-    remove_packages /tmp/selected_packages.txt
+        # Remove packages
+        remove_packages /tmp/selected_packages.txt
 
-    # Check if any packages still need to be removed, retry if needed
-    MISSING_PACKAGE_COUNT=0
-    while read -r package; do
-        if pacman -Qi "$package" &> /dev/null; then
-            MISSING_PACKAGE_COUNT=$((MISSING_PACKAGE_COUNT + 1))
+        # Check if any packages still need to be removed, retry if needed
+        MISSING_PACKAGE_COUNT=0
+        while read -r package; do
+                if pacman -Qi "$package" &>/dev/null; then
+                        MISSING_PACKAGE_COUNT=$((MISSING_PACKAGE_COUNT + 1))
+                fi
+        done </tmp/selected_packages.txt
+
+        if [ $MISSING_PACKAGE_COUNT -gt 0 ]; then
+                ATTEMPT=$((ATTEMPT + 1))
+                echo "Attempt #$ATTEMPT failed, retrying..."
+        else
+                break
         fi
-    done < /tmp/selected_packages.txt
-
-    if [ $MISSING_PACKAGE_COUNT -gt 0 ]; then
-        ATTEMPT=$((ATTEMPT + 1))
-        echo "Attempt #$ATTEMPT failed, retrying..."
-    else
-        break
-    fi
 done
 
 printf "\n%.0s" {1..1}
 printf "\n%s${SKY_BLUE}Attempting to remove locally installed packages${RESET}\n" "${NOTE}"
 for file in ags pokemon-colorscripts; do
-    if [ -f "/usr/local/bin/$file" ]; then
-        sudo rm "/usr/local/bin/$file"
-        echo "$file removed."
-    fi
+        if [ -f "/usr/local/bin/$file" ]; then
+                sudo rm "/usr/local/bin/$file"
+                echo "$file removed."
+        fi
 done
 
 printf "\n%.0s" {1..1}


### PR DESCRIPTION
## Summary
- Replace `swww` wallpaper engine with `awww` in all installation scripts
- Update package references in 3 files: `01-hypr-pkgs.sh`, `02-Final-Check.sh`, and `uninstall.sh`

## Motivation
`awww` appears to be the correct package name for the wallpaper engine, replacing the incorrect `swww` reference.

## Changes Made
1. **install-scripts/01-hypr-pkgs.sh**: Updated package list
2. **install-scripts/02-Final-Check.sh**: Updated final verification check
3. **uninstall.sh**: Updated uninstall script package list

## Type of Change
- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] My commit message follows the commit guidelines
- [x] My change does not require documentation update
- [x] I have tested my code locally and it works as expected

## Additional Context
This change ensures the installation scripts reference the correct wallpaper engine package name (`awww` instead of `swww`).