### PR TITLE
Feature: Dependencies for Rofi-Calc and RofiBeats Background Engine

### DIFF
--- a/install-scripts/01-hypr-pkgs.sh
+++ b/install-scripts/01-hypr-pkgs.sh
@@ -49,7 +49,9 @@ hypr_package=(
         qt6-declarative
         qt6-svg
         rofi
+        rofi-calc
         slurp
+        socat
         swappy
         swaync
         awww


### PR DESCRIPTION
Adds `rofi-calc` (for the pro calculator) and `socat` (for the upcoming RofiBeats 0-second Auto-Radio engine). `jq` and `mpv-mpris` are already present in the list.